### PR TITLE
added soundcloud embed

### DIFF
--- a/assets/app/bunker.js
+++ b/assets/app/bunker.js
@@ -6,7 +6,8 @@ window.app = angular.module('bunker', [
 	'angularMoment',
 	'ui.bootstrap',
 	'youtube-embed',
-	'angular.filter'
+	'angular.filter',
+	'plangular' /* soundcloud embed */
 ])
 	.config(function (sailsResourceProvider, $stateProvider, $urlRouterProvider) {
 		sailsResourceProvider.configuration = {

--- a/assets/app/messages/bunkerMessage.js
+++ b/assets/app/messages/bunkerMessage.js
@@ -1,12 +1,18 @@
 /* global app, _ */
 
 // callback from twitter to embed tweet html
-window.addTweet = function(data){
+window.addTweet = function (data) {
 	var id = data.url.substr(data.url.lastIndexOf('/') + 1);
 	var element = $('.tweet_' + id);
 	element.empty();
 	element.append(data.html);
 };
+
+app.filter('trusted', ['$sce', function ($sce) {
+	return function (url) {
+		return $sce.trustAsResourceUrl(url);
+	};
+}]);
 
 app.directive('bunkerMessage', function ($compile, emoticons) {
 	'use strict';
@@ -137,6 +143,14 @@ app.directive('bunkerMessage', function ($compile, emoticons) {
 								'<script src="https://api.twitter.com/1/statuses/oembed.json?id=' + id + '&amp;callback=addTweet&amp;omit_script=true">' +
 								'</script></div></div>');
 							}
+						}
+						else if (/(www\.)?(soundcloud\.com\/[a-zA-Z0-9])/i.test(link) && !attachedMedia) {
+							attachedMedia = angular.element('' +
+							'<div message="bunkerMessage" bunker-media="' + link + '">' +
+							'<div plangular="' + link + '">' +
+							'<iframe width="100%" height="166" scrolling="no" frameborder="no" ' +
+							'src="{{ \'https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/\' + id + \'&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false\' | trusted}}"></iframe>' +
+							'</div></div>');
 						}
 					}
 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -22,6 +22,7 @@
 	<script src="/assets/vendor/angular-moment/angular-moment.js"></script>
 	<script src="/assets/vendor/bootstrap/dist/js/bootstrap.js"></script>
 	<script src="//cdn.socket.io/socket.io-1.3.3.js"></script>
+	<script src="//d2v52k3cl9vedd.cloudfront.net/plangular/2.0-beta-1/ng-plangular.min.js"></script>
 	<script src="/assets/vendor/sails.io.js/sails.io.js"></script>
 	<script src="/assets/vendor/angular-resource-sails/src/sailsResource.js"></script>
 	<script src="/assets/vendor/angular-youtube-mb/src/angular-youtube-embed.js"></script>


### PR DESCRIPTION
Added support for soundcloud player embed. To embed the player after pasting a link to a soundcloud track, a track ID is needed. To get the ID, I chose to use the Plangular directive, which is an open source directive for embedding soundcloud players. Thus, the bunker.js and index.ejs files have been modified to include the plangular dependencies. 